### PR TITLE
Add Task Management resource to the API

### DIFF
--- a/src/data/seed.ts
+++ b/src/data/seed.ts
@@ -1,4 +1,4 @@
-import type { User, Calendar, Event, NotificationPreferences } from "../types/index.js";
+import type { User, Calendar, Event, NotificationPreferences, Task } from "../types/index.js";
 
 export const users: User[] = [
   {
@@ -65,6 +65,28 @@ export const events: Event[] = [
     reminders: [{ minutes: 15 }],
     recurring: { frequency: "weekly" },
     createdAt: "2026-06-18T12:00:00Z",
+  },
+];
+
+export const tasks: Task[] = [
+  {
+    id: "task-1",
+    userId: "user-1",
+    calendarId: "cal-1",
+    title: "Book travel for conference",
+    notes: "Check flights to NYC for the Q3 summit",
+    dueAt: "2026-06-30T17:00:00Z",
+    completed: false,
+    createdAt: "2026-06-20T09:00:00Z",
+  },
+  {
+    id: "task-2",
+    userId: "user-1",
+    title: "Review sprint backlog",
+    dueAt: "2026-07-06T09:00:00Z",
+    completed: true,
+    completedAt: "2026-07-05T14:22:00Z",
+    createdAt: "2026-06-15T10:00:00Z",
   },
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import usersRoute from "./routes/users.js";
 import calendarsRoute from "./routes/calendars.js";
 import eventsRoute from "./routes/events.js";
 import notificationsRoute from "./routes/notifications.js";
+import tasksRoute from "./routes/tasks.js";
 
 const app = new Hono();
 
@@ -26,11 +27,13 @@ app.use("/users/*", authMiddleware);
 app.use("/calendars/*", authMiddleware);
 app.use("/events/*", authMiddleware);
 app.use("/notifications/*", authMiddleware);
+app.use("/tasks/*", authMiddleware);
 
 app.route("/users", usersRoute);
 app.route("/calendars", calendarsRoute);
 app.route("/events", eventsRoute);
 app.route("/notifications", notificationsRoute);
+app.route("/tasks", tasksRoute);
 
 // Mount calendar-scoped event listing under /calendars
 app.use("/calendars/:calendarId/events", authMiddleware);

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -1,0 +1,102 @@
+import { Hono } from "hono";
+import { tasks, calendars } from "../data/seed.js";
+import type { Task } from "../types/index.js";
+
+const tasksRoute = new Hono<{ Variables: { userId: string } }>();
+
+// GET /tasks — list the current user's tasks
+// Optional query params: ?calendarId=cal-1&completed=true|false
+tasksRoute.get("/", (c) => {
+  const userId = c.get("userId");
+  const { calendarId, completed } = c.req.query();
+
+  let result = tasks.filter((t) => t.userId === userId);
+
+  if (calendarId !== undefined) {
+    result = result.filter((t) => t.calendarId === calendarId);
+  }
+
+  if (completed !== undefined) {
+    const isDone = completed === "true";
+    result = result.filter((t) => t.completed === isDone);
+  }
+
+  return c.json(result);
+});
+
+// POST /tasks — create a task
+tasksRoute.post("/", async (c) => {
+  const userId = c.get("userId");
+  const body = await c.req.json<
+    Pick<Task, "title"> & Partial<Pick<Task, "calendarId" | "notes" | "dueAt">>
+  >();
+
+  if (!body.title) return c.json({ error: "title is required" }, 400);
+
+  if (body.calendarId) {
+    const cal = calendars.find((cal) => cal.id === body.calendarId);
+    const hasAccess =
+      cal && (cal.ownerId === userId || cal.members.some((m) => m.userId === userId));
+    if (!hasAccess) return c.json({ error: "Calendar not found or access denied" }, 403);
+  }
+
+  const newTask: Task = {
+    id: `task-${Date.now()}`,
+    userId,
+    calendarId: body.calendarId,
+    title: body.title,
+    notes: body.notes,
+    dueAt: body.dueAt,
+    completed: false,
+    createdAt: new Date().toISOString(),
+  };
+
+  tasks.push(newTask);
+  return c.json(newTask, 201);
+});
+
+// GET /tasks/:id
+tasksRoute.get("/:id", (c) => {
+  const userId = c.get("userId");
+  const task = tasks.find((t) => t.id === c.req.param("id"));
+  if (!task) return c.json({ error: "Task not found" }, 404);
+  if (task.userId !== userId) return c.json({ error: "Forbidden" }, 403);
+  return c.json(task);
+});
+
+// PATCH /tasks/:id — update fields or mark complete/incomplete
+tasksRoute.patch("/:id", async (c) => {
+  const userId = c.get("userId");
+  const task = tasks.find((t) => t.id === c.req.param("id"));
+  if (!task) return c.json({ error: "Task not found" }, 404);
+  if (task.userId !== userId) return c.json({ error: "Forbidden" }, 403);
+
+  const body = await c.req.json<
+    Partial<Pick<Task, "title" | "notes" | "dueAt" | "calendarId" | "completed">>
+  >();
+
+  if (body.title !== undefined) task.title = body.title;
+  if (body.notes !== undefined) task.notes = body.notes;
+  if (body.dueAt !== undefined) task.dueAt = body.dueAt;
+  if (body.calendarId !== undefined) task.calendarId = body.calendarId;
+
+  if (body.completed !== undefined && body.completed !== task.completed) {
+    task.completed = body.completed;
+    task.completedAt = body.completed ? new Date().toISOString() : undefined;
+  }
+
+  return c.json(task);
+});
+
+// DELETE /tasks/:id
+tasksRoute.delete("/:id", (c) => {
+  const userId = c.get("userId");
+  const index = tasks.findIndex((t) => t.id === c.req.param("id"));
+  if (index === -1) return c.json({ error: "Task not found" }, 404);
+  if (tasks[index].userId !== userId) return c.json({ error: "Forbidden" }, 403);
+
+  tasks.splice(index, 1);
+  return c.json({ message: "Task deleted" });
+});
+
+export default tasksRoute;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,18 @@ export interface Event {
   createdAt: string;
 }
 
+export interface Task {
+  id: string;
+  userId: string;
+  calendarId?: string;
+  title: string;
+  notes?: string;
+  dueAt?: string;
+  completed: boolean;
+  completedAt?: string;
+  createdAt: string;
+}
+
 export interface NotificationPreferences {
   userId: string;
   channels: {


### PR DESCRIPTION
Introduces a Tasks resource that lets users create, view, update, and delete to-do items alongside their calendar events. Tasks are owned by the authenticated user and can optionally be associated with a specific calendar. A completed flag tracks done/not-done state, and completedAt is set (or cleared) automatically when that flag changes.

New endpoints:

  GET    /tasks                   List the current user's tasks.
                                  Supports ?calendarId= and ?completed=
                                  true|false query filters.
  POST   /tasks                   Create a task. Requires title.
                                  Accepts calendarId, notes, dueAt.
  GET    /tasks/:id               Fetch a single task by ID.
  PATCH  /tasks/:id               Update any field. Toggling completed
                                  to true stamps completedAt; toggling
                                  back to false clears it.
  DELETE /tasks/:id               Delete a task.

All endpoints are protected by the existing Bearer token middleware. Calendar access is validated when calendarId is provided on create.